### PR TITLE
fix: change legend tag to header tag, to allow compatibility with flex

### DIFF
--- a/web/src/pages/CreatePoint/index.tsx
+++ b/web/src/pages/CreatePoint/index.tsx
@@ -170,9 +170,9 @@ const CreatePoint = () => {
         <Dropzone onFileUploaded={setSelectedFile} />
 
         <fieldset>
-          <legend>
+          <header role="legend">
             <h2>Dados</h2>
-          </legend>
+          </header>
 
           <div className="field">
             <label htmlFor="name">Nome da entidade</label>
@@ -207,10 +207,10 @@ const CreatePoint = () => {
         </fieldset>
 
         <fieldset>
-          <legend>
+          <header role="legend">
             <h2>Endereço</h2>
             <span>Selecione o endereço no mapa</span>
-          </legend>
+          </header>
 
           <Map center={initialPosition} zoom={15} onClick={handleMapClick}>
             <TileLayer
@@ -254,10 +254,10 @@ const CreatePoint = () => {
         </fieldset>
 
         <fieldset>
-          <legend>
+          <header role="legend">
             <h2>Ítens de coleta</h2>
             <span>Selecione um ou mais ítens abaixo</span>
-          </legend>
+          </header>
 
           <ul className="items-grid">
             {items.map(item => (

--- a/web/src/pages/CreatePoint/styles.css
+++ b/web/src/pages/CreatePoint/styles.css
@@ -48,7 +48,7 @@
   border: 0;
 }
 
-#page-create-point form legend {
+#page-create-point form header[role="legend"] {
   width: 100%;
   display: flex;
   justify-content: space-between;
@@ -56,11 +56,11 @@
   margin-bottom: 40px;
 }
 
-#page-create-point form legend h2 {
+#page-create-point form header[role="legend"] h2 {
   font-size: 24px;
 }
 
-#page-create-point form legend span {
+#page-create-point form header[role="legend"] span {
   font-size: 14px;
   font-weight: normal;
   color: var(--text-color);


### PR DESCRIPTION
Firefox não dá suporte ao `display:flex` na tag `<legend>`. Dessa forma, o título e a descrição aparecem um abaixo do outro, ao invés de um ao lado do outro, como desejado.

[Acesse o codepen](https://codepen.io/diegosomar/pen/XWXgdQr) no Firefox para reproduzir o erro.

Para manter a semântica, optei por substituir a tag `<legend>` pela tag `<header>`. Como o conteúdo da `legend` aparece no topo do formulário, penso que a tag `header` é a mais semântica, nesse caso. Para incrementar ainda mais a semântica, foi aplicado o atributo `role="legend"` na tag `header`.

Poderia ter sido aplicado o `float` nesse caso, mas já estamos em 2020...

Tanto o erro quanto a solução foram testadas no Firefox 75 com MacOS Catalina.