### PR TITLE
fix: fundo do button na Home

### DIFF
--- a/mobile/src/pages/Home/index.tsx
+++ b/mobile/src/pages/Home/index.tsx
@@ -125,6 +125,8 @@ const styles = StyleSheet.create({
     height: 60,
     width: 60,
     backgroundColor: 'rgba(0, 0, 0, 0.1)',
+    borderTopLeftRadius: 10,
+    borderBottomLeftRadius: 10,
     justifyContent: 'center',
     alignItems: 'center'
   },


### PR DESCRIPTION
Alteração no radius do buttonIcon, porque ele é uma caixa quadrada com fundo preto 'transparente', e essa caixa estava ultrapassando os limites da borda do botão em si.

Aqui neste [link do Imgur](https://imgur.com/a/5sygGBt) eu coloquei 3 imagens onde demonstro a tela inicial e depois a tela corrigida.

Dispositivo: Samsumg S5 Mini (SM-G800H)
Sistema operacional: Stock Android Marshmallow 6.0.1
Expo: 2.16.1