### PR TITLE
New Feature: select picker on mobile homepage

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -22,6 +22,7 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
     "react-native-gesture-handler": "~1.6.0",
     "react-native-maps": "0.26.1",
+    "react-native-picker-select": "^7.0.0",
     "react-native-reanimated": "~1.7.0",
     "react-native-safe-area-context": "0.7.3",
     "react-native-screens": "~2.2.0",

--- a/mobile/src/pages/Detail/index.tsx
+++ b/mobile/src/pages/Detail/index.tsx
@@ -78,12 +78,12 @@ const Detail = () => {
         </View>
       </View>
       <View style={styles.footer}>
-        <RectButton style={styles.button} onPress={handleWhatsapp}>
+        <RectButton rippleColor='#2FB86E' style={styles.button} onPress={handleWhatsapp}>
           <FontAwesome name="whatsapp" size={20} color="#FFF" />
           <Text style={styles.buttonText}>Whatsapp</Text>
         </RectButton>
 
-        <RectButton style={styles.button} onPress={handleComposeMail}>
+        <RectButton rippleColor='#2FB86E' style={styles.button} onPress={handleComposeMail}>
           <Icon name="mail" size={20} color="#FFF" />
           <Text style={styles.buttonText}>E-mail</Text>
         </RectButton>

--- a/mobile/src/pages/Home/index.tsx
+++ b/mobile/src/pages/Home/index.tsx
@@ -120,7 +120,7 @@ const Home = () => {
             items={cities}
           />
 
-          <RectButton style={styles.button} onPress={handleNavigateToPoints}>
+          <RectButton rippleColor='#2FB86E' style={styles.button} onPress={handleNavigateToPoints}>
             <View style={styles.buttonIcon}>
               <Text>
                 <Icon name="arrow-right" color="#FFF" size={24} />


### PR DESCRIPTION
Como mencionado na aula sobre mobile da NLW-01, foi sugerido pelo Diego construir um select picker na página inicial do mobile utilizando a biblioteca [react-native-picker-select](https://www.npmjs.com/package/react-native-picker-select).

Implementei a biblioteca com o mesmo funcionamento do select picker implementado na versão web (Carregando as cidades conforme UF selecionada). O layout final se encontra na imagem abaixo.

Além disso, foi adicionada a propriedade rippleColor com a cor do ripple nos botões retangulares (RectButton), pois o ripple não estava funcionando no Android.

Alterei o IP do Expo, executei o projeto, e verifiquei que o funcionamento está correto. (Não foram commitadas as mudanças de IP's no código e nem os packages-lock.json)

Espero que aceitem meu PR, visto que faz um tempo desde a NLW-Ecoleta.

Obrigado! 
Att. Arthur de Bortoli

![layout](https://user-images.githubusercontent.com/33229271/88349923-d8075800-cd27-11ea-8fd3-207524494573.jpg)


