### PR TITLE
feat: Limpa pontos do mapa quando não há nenhum item selecionado

### DIFF
--- a/mobile/src/pages/Points/index.tsx
+++ b/mobile/src/pages/Points/index.tsx
@@ -123,7 +123,7 @@ const Points = () => {
                 longitudeDelta: 0.014,
               }}
             >
-              {points.map(point => (
+              {selectedItems[0] !== undefined && (points.map(point => (
                 <Marker 
                   key={String(point.id)}
                   style={styles.mapMarker}
@@ -138,7 +138,7 @@ const Points = () => {
                     <Text style={styles.mapMarkerTitle}>{point.name}</Text>                
                   </View>
                 </Marker>
-              ))}
+              )))}
             </MapView>
           ) }
         </View>


### PR DESCRIPTION
Evita que a aplicação trave ao desmarcar todos os itens na aplicação mobile, assim os pontos do mapa não são exibidos quando não há nenhum item marcado.